### PR TITLE
Feature request: smaller font size for notification bar

### DIFF
--- a/firefdskit/src/main/java/sb/firefds/q/firefdskit/XSysUINotificationPanelPackage.java
+++ b/firefdskit/src/main/java/sb/firefds/q/firefdskit/XSysUINotificationPanelPackage.java
@@ -52,7 +52,8 @@ public class XSysUINotificationPanelPackage {
     private static ClassLoader classLoader;
 
     static {
-        CARRIER_SIZES_MAP.put("Tiny", 12);
+        CARRIER_SIZES_MAP.put("Tiny", 10);
+        CARRIER_SIZES_MAP.put("Smaller", 12);
         CARRIER_SIZES_MAP.put("Small", 14);
         CARRIER_SIZES_MAP.put("Medium", 16);
         CARRIER_SIZES_MAP.put("Large", 18);

--- a/firefdskit/src/main/java/sb/firefds/q/firefdskit/XSysUINotificationPanelPackage.java
+++ b/firefdskit/src/main/java/sb/firefds/q/firefdskit/XSysUINotificationPanelPackage.java
@@ -52,6 +52,7 @@ public class XSysUINotificationPanelPackage {
     private static ClassLoader classLoader;
 
     static {
+        CARRIER_SIZES_MAP.put("Tiny", 12);
         CARRIER_SIZES_MAP.put("Small", 14);
         CARRIER_SIZES_MAP.put("Medium", 16);
         CARRIER_SIZES_MAP.put("Large", 18);

--- a/firefdskit/src/main/res/values/arrays.xml
+++ b/firefdskit/src/main/res/values/arrays.xml
@@ -12,6 +12,7 @@
     </string-array>
     <string-array name="carrier_size_entries">
         <item name="tiny">@string/tiny</item>
+        <item name="smaller">@string/smaller</item>
         <item name="small">@string/small</item>
         <item name="medium">@string/medium</item>
         <item name="large">@string/large</item>
@@ -19,6 +20,8 @@
         <item name="largest">@string/largest</item>
     </string-array>
     <string-array name="carrier_size_values">
+        <item name="tiny">Tiny</item>
+        <item name="smaller">Smaller</item>
         <item name="small">Small</item>
         <item name="medium">Medium</item>
         <item name="large">Large</item>

--- a/firefdskit/src/main/res/values/arrays.xml
+++ b/firefdskit/src/main/res/values/arrays.xml
@@ -11,6 +11,7 @@
         <item name="screen_off">2</item>
     </string-array>
     <string-array name="carrier_size_entries">
+        <item name="tiny">@string/tiny</item>
         <item name="small">@string/small</item>
         <item name="medium">@string/medium</item>
         <item name="large">@string/large</item>

--- a/firefdskit/src/main/res/values/strings.xml
+++ b/firefdskit/src/main/res/values/strings.xml
@@ -86,6 +86,7 @@
     <string name="advanced_power_menu_title">Advanced Power Menu</string>
     <string name="advanced_power_menu">Power menu</string>
     <string name="tiny">Tiny</string>
+    <string name="smaller">Smaller</string>
     <string name="small">Small</string>
     <string name="medium">Medium</string>
     <string name="large">Large</string>

--- a/firefdskit/src/main/res/values/strings.xml
+++ b/firefdskit/src/main/res/values/strings.xml
@@ -85,6 +85,7 @@
     <string name="add_screenshot_to_power_menu">Enable Screenshot in power menu</string>
     <string name="advanced_power_menu_title">Advanced Power Menu</string>
     <string name="advanced_power_menu">Power menu</string>
+    <string name="tiny">Tiny</string>
     <string name="small">Small</string>
     <string name="medium">Medium</string>
     <string name="large">Large</string>


### PR DESCRIPTION
Hi, very much enjoying the kit, thanks! 

One thing I've noticed, however, is that even the "Small" text size for the notification bar clock is actually larger than what I get with stock (and thus taking up too much space for my taste), so I'd propose to add one or two new options on the smaller end of the spectrum.

I *think* the edits I made should be sufficient to accomplish this, but then again I'm not too familiar with this type of code and I can't test it myself, so just a potential suggestion really